### PR TITLE
fix: handle case where logger lambda is undefined

### DIFF
--- a/src/lib/tailLogsForLambdas/index.ts
+++ b/src/lib/tailLogsForLambdas/index.ts
@@ -69,7 +69,12 @@ const tailLogsForLambdas = async (
       realTimeLogsFunctionMap[key].map(({functionName}) => functionName),
     )
       .on('log', (log) => {
-        loggers[log.lambda].log(...log.log);
+        if (loggers[log.lambda]) {
+          loggers[log.lambda].log(...log.log);
+        } else {
+          // eslint-disable-next-line no-console
+          console.log(...log.log);
+        }
       })
       .on('disconnect', () => {
         // eslint-disable-next-line no-console


### PR DESCRIPTION
Prevents issues where the logger is undefined, that can happen when a log comes from an installed package rather than the lambda its self