### PR TITLE
fix: logs should prefix with the cdk path not function name

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn commitlint --edit 
+yarn commitlint --edit

--- a/src/lib/tailLogsForLambdas/index.ts
+++ b/src/lib/tailLogsForLambdas/index.ts
@@ -24,7 +24,6 @@ const tailLogsForLambdas = async (
       if (!found) throw new Error('Lambda key not found'); // should never happen.
       return found;
     })
-    .map(({functionName}) => functionName);
 
   // Keyed by the endpoint, values are arrays of lambda details
   const realTimeLogsFunctionMap = forceCloudwatch
@@ -44,9 +43,9 @@ const tailLogsForLambdas = async (
           };
         }, {} as Record<string, LambdaDetail[]>);
 
-  cloudwatchFunctions.forEach((name) => {
-    const logger = createCLILoggerForLambda(name, lambdaFunctions.length > 1);
-    tailCloudWatchLogsForLambda(name)
+  cloudwatchFunctions.forEach((lambda) => {
+    const logger = createCLILoggerForLambda(lambda.lambdaCdkPath, lambdaFunctions.length > 1);
+    tailCloudWatchLogsForLambda(lambda.functionName)
       .on('log', (log) => logger.log(log.toString()))
       .on('error', (log) => logger.error(log));
   });

--- a/src/lib/tailLogsForLambdas/index.ts
+++ b/src/lib/tailLogsForLambdas/index.ts
@@ -18,12 +18,11 @@ const tailLogsForLambdas = async (
     : Object.keys(realTimeEndpointsForLambdas).filter(
         (key) => !realTimeEndpointsForLambdas[key],
       )
-  )
-    .map((key) => {
-      const found = lambdaFunctions.find((func) => func.lambdaCdkPath === key);
-      if (!found) throw new Error('Lambda key not found'); // should never happen.
-      return found;
-    })
+  ).map((key) => {
+    const found = lambdaFunctions.find((func) => func.lambdaCdkPath === key);
+    if (!found) throw new Error('Lambda key not found'); // should never happen.
+    return found;
+  });
 
   // Keyed by the endpoint, values are arrays of lambda details
   const realTimeLogsFunctionMap = forceCloudwatch
@@ -44,7 +43,10 @@ const tailLogsForLambdas = async (
         }, {} as Record<string, LambdaDetail[]>);
 
   cloudwatchFunctions.forEach((lambda) => {
-    const logger = createCLILoggerForLambda(lambda.lambdaCdkPath, lambdaFunctions.length > 1);
+    const logger = createCLILoggerForLambda(
+      lambda.lambdaCdkPath,
+      lambdaFunctions.length > 1,
+    );
     tailCloudWatchLogsForLambda(lambda.functionName)
       .on('log', (log) => logger.log(log.toString()))
       .on('error', (log) => logger.error(log));


### PR DESCRIPTION
Logs from multiple lambdas should prefix with the lambda cdk path, not the function name.